### PR TITLE
Allow running more than one instance of protocol

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -4,7 +4,8 @@
   "seedMultiplier": 100,
   "validatorSettings": {
     "numNodes": 32,
-    "numConsensus": 2000,
+    "numConsensus": 1000,
+    "numPrograms": 2,
     "baseTimeLimit": 10000,
     "nodeProcessingDistribution": {
       "distributionType": "exp",

--- a/src/main/java/simulation/event/TimedEvent.java
+++ b/src/main/java/simulation/event/TimedEvent.java
@@ -18,16 +18,18 @@ public class TimedEvent<T extends BFTMessage> extends NodeEvent<T> {
 
     private final Validator<T> node;
     private final int id;
+    private final int timerCount;
 
-    public TimedEvent(double time, Validator<T> node, int id) {
+    public TimedEvent(double time, Validator<T> node, int id, int timerCount) {
         super(time, node);
         this.node = node;
         this.id = id;
+        this.timerCount = timerCount;
     }
 
     @Override
     public List<NodeEvent<T>> simulate() {
-        return convertPayloadsToQueueEvents(getTime(), node, node.notifyTime(id));
+        return convertPayloadsToQueueEvents(getTime(), node, node.notifyTime(id, timerCount));
     }
 
     @Override

--- a/src/main/java/simulation/json/input/ValidatorConfigJson.java
+++ b/src/main/java/simulation/json/input/ValidatorConfigJson.java
@@ -4,6 +4,7 @@ public class ValidatorConfigJson {
 
     private int numNodes;
     private int numConsensus;
+    private int numPrograms;
     private String consensusProtocol;
     private double baseTimeLimit;
     private RngConfigJson nodeProcessingDistribution;
@@ -11,6 +12,10 @@ public class ValidatorConfigJson {
 
     public int getNumConsensus() {
         return numConsensus;
+    }
+
+    public int getNumPrograms() {
+        return numPrograms;
     }
 
     public RngConfigJson getNodeProcessingDistribution() {

--- a/src/main/java/simulation/network/entity/BFTMessage.java
+++ b/src/main/java/simulation/network/entity/BFTMessage.java
@@ -3,4 +3,5 @@ package simulation.network.entity;
 public abstract class BFTMessage {
 
     public abstract String getType();
+    public abstract int getRecipientId();
 }

--- a/src/main/java/simulation/network/entity/Payload.java
+++ b/src/main/java/simulation/network/entity/Payload.java
@@ -9,10 +9,12 @@ public class Payload<T> {
 
     private final T message;
     private final String destination;
+    private final int programId;
 
-    public Payload(T message, String destination) {
+    public Payload(T message, String destination, int programId) {
         this.message = message;
         this.destination = destination;
+        this.programId = programId;
     }
 
     public String getDestination() {
@@ -22,6 +24,11 @@ public class Payload<T> {
     public T getMessage() {
         return message;
     }
+
+    public int getProgramId() {
+        return programId;
+    }
+
     @Override
     public String toString() {
         return "Payload: (" + message + ", " + destination + ")";

--- a/src/main/java/simulation/network/entity/Validator.java
+++ b/src/main/java/simulation/network/entity/Validator.java
@@ -91,12 +91,11 @@ public class Validator<T extends BFTMessage> extends EndpointNode<T>
     @Override
     public Pair<Double, List<Payload<T>>> processPayload(double time, Payload<T> payload) {
         double duration = rng.generateRandomNumber();
-        double timePassed = time - previousRecordedTime;
         previousRecordedTime = time + duration;
         T message = payload.getMessage();
         int programId = payload.getProgramId();
         ConsensusProgram<T> consensusProgram = consensusPrograms.get(programId);
-        consensusProgram.registerMessageProcessed(message, duration + timePassed);
+        consensusProgram.registerMessageProcessed(message, previousRecordedTime);
         List<T> responseMessages = consensusProgram.processMessage(message);
         return new Pair<>(duration, convertMessagesToPayloads(responseMessages, programId));
     }

--- a/src/main/java/simulation/network/entity/Validator.java
+++ b/src/main/java/simulation/network/entity/Validator.java
@@ -2,7 +2,6 @@ package simulation.network.entity;
 
 import simulation.network.entity.timer.TimerNotifier;
 import simulation.protocol.ConsensusProgram;
-import simulation.protocol.NoProgram;
 import simulation.simulator.ValidatorResults;
 import simulation.statistics.ConsensusStatistics;
 import simulation.util.Pair;
@@ -11,6 +10,7 @@ import simulation.util.rng.RandomNumberGenerator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Encapsulates an {@code EndpointNode} that runs a BFT protocol.
@@ -25,7 +25,10 @@ public class Validator<T extends BFTMessage> extends EndpointNode<T>
     private final TimerNotifier<Validator<T>> timerNotifier;
     private final RandomNumberGenerator rng;
 
-    private ConsensusProgram<T> consensusProgram;
+    private final Map<Integer, String> idNodeNameMap;
+    private final Map<Integer, ConsensusProgram<T>> consensusPrograms;
+    private final Map<ConsensusProgram<T>, Integer> programToIdMap;
+
     private double previousRecordedTime;
 
     /**
@@ -34,37 +37,44 @@ public class Validator<T extends BFTMessage> extends EndpointNode<T>
      * @param timerNotifier TimerNotifier to check time and set timers.
      * @param serviceTimeGenerator RNG for service time.
      */
-    public Validator(String name, int consensusLimit, TimerNotifier<Validator<T>> timerNotifier,
+    public Validator(String name, Map<Integer, String> idNodeNameMap, int consensusLimit,
+            TimerNotifier<Validator<T>> timerNotifier,
             RandomNumberGenerator serviceTimeGenerator) {
         super(name);
         this.timerNotifier = timerNotifier;
+        this.idNodeNameMap = idNodeNameMap;
         this.rng = serviceTimeGenerator;
         this.allNodes = new HashMap<>();
         this.consensusLimit = consensusLimit;
-        this.consensusProgram = new NoProgram<T>();
+        this.consensusPrograms = new HashMap<>();
+        this.programToIdMap = new HashMap<>();
     }
 
-    public void setConsensusProgram(ConsensusProgram<T> consensusProgram) {
-        this.consensusProgram = consensusProgram;
+    public void addConsensusProgram(ConsensusProgram<T> consensusProgram) {
+        this.consensusPrograms.put(this.consensusPrograms.size() + 1, consensusProgram);
+        this.programToIdMap.put(consensusProgram, this.programToIdMap.size() + 1);
     }
 
     @Override
-    public ConsensusStatistics getConsensusStatistics() {
-        return consensusProgram.getStatistics();
+    public ConsensusStatistics getConsensusStatistics(int programNumber) {
+        return consensusPrograms.get(programNumber).getStatistics();
     }
 
-    public int getConsensusCount() {
-        return consensusProgram.getConsensusCount();
+    @Override
+    public int getNumConsensusPrograms() {
+        return consensusPrograms.size();
     }
 
     @Override
     public boolean isStillRequiredToRun() {
-        return getConsensusCount() < consensusLimit;
+        return consensusPrograms.values().stream().anyMatch(p -> p.getConsensusCount() < consensusLimit);
     }
 
     @Override
     public List<Payload<T>> initializationPayloads() {
-        return consensusProgram.initializationPayloads();
+        return consensusPrograms.keySet().stream()
+                .flatMap(x -> convertMessagesToPayloads(consensusPrograms.get(x).initializationPayloads(), x).stream())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -84,18 +94,29 @@ public class Validator<T extends BFTMessage> extends EndpointNode<T>
         double timePassed = time - previousRecordedTime;
         previousRecordedTime = time + duration;
         T message = payload.getMessage();
+        int programId = payload.getProgramId();
+        ConsensusProgram<T> consensusProgram = consensusPrograms.get(programId);
         consensusProgram.registerMessageProcessed(message, duration + timePassed);
-        List<Payload<T>> payloads = consensusProgram.processMessage(message);
-        return new Pair<>(duration, payloads);
+        List<T> responseMessages = consensusProgram.processMessage(message);
+        return new Pair<>(duration, convertMessagesToPayloads(responseMessages, programId));
     }
 
-    public List<Payload<T>> notifyTime(int timerCount) {
-        return consensusProgram.notifyTime(timerCount);
+    private String getIdNodeName(int id) {
+        return idNodeNameMap.get(id);
+    }
+
+    private List<Payload<T>> convertMessagesToPayloads(List<? extends T> messages, int programId) {
+        return messages.stream().map(m -> new Payload<T>(m, getIdNodeName(m.getRecipientId()), programId))
+                .collect(Collectors.toList());
+    }
+
+    public List<Payload<T>> notifyTime(int id, int timerCount) {
+        return convertMessagesToPayloads(consensusPrograms.get(id).notifyTime(timerCount), id);
     }
 
     @Override
-    public void notifyAtTime(ConsensusProgram<T> program, double time, int timerCount) {
-        timerNotifier.notifyAtTime(this, time, timerCount);
+    public void notifyAtTime(ConsensusProgram<T> program, double time, int id, int timerCount) {
+        timerNotifier.notifyAtTime(this, time, programToIdMap.get(program), timerCount);
     }
 
     @Override
@@ -105,6 +126,6 @@ public class Validator<T extends BFTMessage> extends EndpointNode<T>
 
     @Override
     public String toString() {
-        return super.toString() + ": " + consensusProgram.toString();
+        return super.toString() + ": " + consensusPrograms.toString();
     }
 }

--- a/src/main/java/simulation/network/entity/fault/UnresponsiveValidator.java
+++ b/src/main/java/simulation/network/entity/fault/UnresponsiveValidator.java
@@ -43,7 +43,7 @@ public class UnresponsiveValidator<T extends BFTMessage> extends Validator<T> {
     }
 
     @Override
-    public void notifyAtTime(ConsensusProgram<T> program, double time, int timerCount) {
+    public void notifyAtTime(ConsensusProgram<T> program, double time, int id, int timerCount) {
         return;
     }
 }

--- a/src/main/java/simulation/network/entity/fault/UnresponsiveValidator.java
+++ b/src/main/java/simulation/network/entity/fault/UnresponsiveValidator.java
@@ -10,6 +10,7 @@ import simulation.util.rng.ExponentialDistribution;
 import simulation.util.rng.RandomNumberGenerator;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a defunct validator that stopped responding.
@@ -24,7 +25,7 @@ public class UnresponsiveValidator<T extends BFTMessage> extends Validator<T> {
      * @param timerNotifier TimerNotifier to check time and set timers.
      */
     public UnresponsiveValidator(String name, TimerNotifier<Validator<T>> timerNotifier) {
-        super(name, DUMMY_CONSENSUS_LIMIT, timerNotifier, DUMMY_RNG);
+        super(name, Map.of(), DUMMY_CONSENSUS_LIMIT, timerNotifier, DUMMY_RNG);
     }
 
     @Override

--- a/src/main/java/simulation/network/entity/timer/TimerNotifier.java
+++ b/src/main/java/simulation/network/entity/timer/TimerNotifier.java
@@ -10,9 +10,10 @@ public interface TimerNotifier<T> {
      *
      * @param receiver Receiver to be notified.
      * @param time Time to be notified.
+     * @param id Integer identification to be notified.
      * @param timerCount An integer unique identifier for this specific notification.
      */
-    void notifyAtTime(T receiver, double time, int timerCount);
+    void notifyAtTime(T receiver, double time, int id, int timerCount);
 
     /**
      * Returns the current {@code time}.

--- a/src/main/java/simulation/protocol/ConsensusProgram.java
+++ b/src/main/java/simulation/protocol/ConsensusProgram.java
@@ -1,7 +1,6 @@
 package simulation.protocol;
 
 import simulation.network.entity.BFTMessage;
-import simulation.network.entity.Payload;
 import simulation.statistics.ConsensusStatistics;
 
 import java.util.Collection;
@@ -17,17 +16,17 @@ public interface ConsensusProgram<T extends BFTMessage> {
     /**
      * Returns the list of resulting payloads as a result of processing {@code message}.
      */
-    List<Payload<T>> processMessage(T message);
+    List<T> processMessage(T message);
 
     /**
      * Returns the list of payloads during initialization of the node.
      */
-    List<Payload<T>> initializationPayloads();
+    List<T> initializationPayloads();
 
     /**
      * Returns the list of payloads as a result of a timer notification.
      */
-    List<Payload<T>> notifyTime(int timerCount);
+    List<T> notifyTime(int timerCount);
 
     /**
      * Registers the effects of {@code timeTaken}

--- a/src/main/java/simulation/protocol/ConsensusProgramImpl.java
+++ b/src/main/java/simulation/protocol/ConsensusProgramImpl.java
@@ -26,6 +26,7 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
     private final int numNodes;
     private int timerCount; // Used to differentiate multiple timers in the same instance & round
     private double timeoutTime;
+    private double previousRecordedTime;
 
     /**
      * @param numNodes Number of nodes in the consensus program.
@@ -37,6 +38,7 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
         this.timerNotifier = timerNotifier;
         this.timeoutTime = 0;
         this.timerCount = 0;
+        this.previousRecordedTime = 0;
         this.statistics = new ConsensusStatistics(getStates());
     }
 
@@ -50,7 +52,9 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
     }
 
     @Override
-    public void registerMessageProcessed(T message, double timeTaken) {
+    public void registerMessageProcessed(T message, double currentTime) {
+        double timeTaken = currentTime - previousRecordedTime;
+        previousRecordedTime = currentTime;
         registerTimeElapsed(timeTaken);
         statistics.addMessageCountForState(message.getType());
     }

--- a/src/main/java/simulation/protocol/ConsensusProgramImpl.java
+++ b/src/main/java/simulation/protocol/ConsensusProgramImpl.java
@@ -1,14 +1,13 @@
 package simulation.protocol;
 
 import simulation.network.entity.BFTMessage;
-import simulation.network.entity.Payload;
 import simulation.network.entity.timer.TimerNotifier;
 import simulation.statistics.ConsensusStatistics;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 
 /**
  * Partial implementation of a consensus program that fulfills general responsibilities.
@@ -20,29 +19,25 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
      * Stores payloads while node is processing a message.
      * All payloads are retrieved and sent out after message processing.
      */
-    private List<Payload<T>> tempPayloadStore;
+    private List<T> tempMessageStore;
 
     private final ConsensusStatistics statistics;
-    private final Map<Integer, String> idNodeNameMap;
     private final TimerNotifier<ConsensusProgram<T>> timerNotifier;
+    private final int numNodes;
     private int timerCount; // Used to differentiate multiple timers in the same instance & round
     private double timeoutTime;
 
     /**
-     * @param idNodeNameMap Map of id to node names.
+     * @param numNodes Number of nodes in the consensus program.
      * @param timerNotifier For tracking time and setting timers.
      */
-    public ConsensusProgramImpl(Map<Integer, String> idNodeNameMap, TimerNotifier<ConsensusProgram<T>> timerNotifier) {
-        this.idNodeNameMap = idNodeNameMap;
-        this.tempPayloadStore = new ArrayList<>();
+    public ConsensusProgramImpl(int numNodes, TimerNotifier<ConsensusProgram<T>> timerNotifier) {
+        this.numNodes = numNodes;
+        this.tempMessageStore = new ArrayList<>();
         this.timerNotifier = timerNotifier;
         this.timeoutTime = 0;
         this.timerCount = 0;
         this.statistics = new ConsensusStatistics(getStates());
-    }
-
-    protected String getNameFromId(int id) {
-        return idNodeNameMap.get(id);
     }
 
     /**
@@ -73,47 +68,28 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
      *
      * @return List of payloads that were generated from a processing step.
      */
-    protected List<Payload<T>> getProcessedPayloads() {
-        List<Payload<T>> payloads = tempPayloadStore;
-        tempPayloadStore = new ArrayList<>();
+    protected List<T> getMessages() {
+        List<T> payloads = tempMessageStore;
+        tempMessageStore = new ArrayList<>();
         return payloads;
     }
 
     /**
      * Sends {@code message} to destination {@code nodeName}.
      */
-    protected void sendMessage(T message, String nodeName) {
-        tempPayloadStore.add(createPayload(message, nodeName));
+    protected void sendMessage(T message) {
+        tempMessageStore.add(message);
     }
 
     /**
      * Sends {@code message} to all nodes in the collection of {@code nodeNames}.
      */
-    protected void broadcastMessage(T message, Collection<String> nodeNames) {
-        tempPayloadStore.addAll(createPayloads(message, nodeNames));
-    }
-
-    protected void broadcastMessageToAll(T message) {
-        broadcastMessage(message, idNodeNameMap.values());
-    }
-
-    public Payload<T> createPayload(T message, String nodeName) {
-        return new Payload<>(message, nodeName);
-    }
-
-    /**
-     * Returns a list of payloads for the {@code message} to all nodes specified in the collection of {@code nodeNames}.
-     */
-    public List<Payload<T>> createPayloads(T message, Collection<String> nodeNames) {
-        List<Payload<T>> payloads = new ArrayList<>();
-        for (String nodeName : nodeNames) {
-            payloads.add(new Payload<>(message, nodeName));
-        }
-        return payloads;
+    protected void broadcastMessage(Function<Integer, T> messageGenerator) {
+        IntStream.iterate(0, x -> x + 1).limit(numNodes)
+                .forEach(id -> sendMessage(messageGenerator.apply(id)));
     }
 
     // Timer utilities
-
     public double getTime() {
         return timerNotifier.getTime();
     }
@@ -123,7 +99,8 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
      * @param id Unique identification for the timer.
      */
     public void notifyAtTime(double time, int id) {
-        timerNotifier.notifyAtTime(this, time, id);
+        // Note here the 0 does not matter for now as the program itself does not need to differentiate timers.
+        timerNotifier.notifyAtTime(this, time, 0, id);
     }
 
     /**
@@ -144,7 +121,7 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
      * @param timerCount int identification for the specific timer.
      * @return List of payloads to be sent at the given time.
      */
-    public List<Payload<T>> notifyTime(int timerCount) {
+    public List<T> notifyTime(int timerCount) {
         if (timerCount == this.timerCount) {
             statistics.addRoundChangeStateCount(getState());
             return onTimerExpiry();
@@ -155,5 +132,5 @@ public abstract class ConsensusProgramImpl<T extends BFTMessage> implements Cons
     /**
      * Operation to be called on timer expiry.
      */
-    protected abstract List<Payload<T>> onTimerExpiry();
+    protected abstract List<T> onTimerExpiry();
 }

--- a/src/main/java/simulation/protocol/NoProgram.java
+++ b/src/main/java/simulation/protocol/NoProgram.java
@@ -1,7 +1,6 @@
 package simulation.protocol;
 
 import simulation.network.entity.BFTMessage;
-import simulation.network.entity.Payload;
 import simulation.statistics.ConsensusStatistics;
 
 import java.util.Collection;
@@ -10,17 +9,17 @@ import java.util.List;
 public class NoProgram<T extends BFTMessage> implements ConsensusProgram<T> {
 
     @Override
-    public List<Payload<T>> processMessage(T message) {
+    public List<T> processMessage(T message) {
         return List.of();
     }
 
     @Override
-    public List<Payload<T>> initializationPayloads() {
+    public List<T> initializationPayloads() {
         return List.of();
     }
 
     @Override
-    public List<Payload<T>> notifyTime(int timerCount) {
+    public List<T> notifyTime(int timerCount) {
         return List.of();
     }
 

--- a/src/main/java/simulation/protocol/hotstuff/HSMessage.java
+++ b/src/main/java/simulation/protocol/hotstuff/HSMessage.java
@@ -14,14 +14,16 @@ public class HSMessage extends BFTMessage {
 
     private final HSMessageType type;
     private final int viewNumber;
+    private final int recipient;
     private final HSTreeNode node;
     private final QuorumCertificate justify;
     private final int sender;
     private final boolean isVote;
 
-    public HSMessage(int sender, HSMessageType type, int viewNumber, HSTreeNode node, QuorumCertificate qc,
-            boolean isVote) {
+    public HSMessage(int sender, int recipient, HSMessageType type, int viewNumber,
+            HSTreeNode node, QuorumCertificate qc, boolean isVote) {
         this.type = type;
+        this.recipient = recipient;
         this.viewNumber = viewNumber;
         this.node = node;
         this.justify = qc;
@@ -36,6 +38,11 @@ public class HSMessage extends BFTMessage {
     @Override
     public String getType() {
         return type.toString();
+    }
+
+    @Override
+    public int getRecipientId() {
+        return recipient;
     }
 
     public int getViewNumber() {

--- a/src/main/java/simulation/protocol/hotstuff/HSReplica.java
+++ b/src/main/java/simulation/protocol/hotstuff/HSReplica.java
@@ -1,6 +1,5 @@
 package simulation.protocol.hotstuff;
 
-import simulation.network.entity.Payload;
 import simulation.network.entity.timer.TimerNotifier;
 import simulation.protocol.ConsensusProgram;
 import simulation.protocol.ConsensusProgramImpl;
@@ -57,7 +56,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
     public HSReplica(String name, int id, double baseTimeLimit, int n,
             Map<Integer, String> idNodeNameMap,
             TimerNotifier<ConsensusProgram<HSMessage>> timerNotifier) {
-        super(idNodeNameMap, timerNotifier);
+        super(n, timerNotifier);
         this.logger = new Logger(name);
         this.numConsensus = 0;
         this.id = id;
@@ -80,16 +79,16 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
     /**
      * Creates a leader {@code HSMessage} of {@code type}, containing {@code node} and {@code qc} as justification.
      */
-    private HSMessage msg(HSMessageType type, HSTreeNode node, QuorumCertificate qc) {
-        return new HSMessage(id, type, curView, node, qc, false);
+    private HSMessage msg(int recipient, HSMessageType type, HSTreeNode node, QuorumCertificate qc) {
+        return new HSMessage(id, recipient, type, curView, node, qc, false);
     }
 
     /**
      * Creates a vote {@code HSMessage} of {@code type}, containing{@code node} and {@code qc} as justification.
      */
-    private HSMessage voteMsg(HSMessageType type, HSTreeNode node, QuorumCertificate qc) {
+    private HSMessage voteMsg(int recipient, HSMessageType type, HSTreeNode node, QuorumCertificate qc) {
         // Here, we ignore the signing component of the vote message as we are not concerned with verification.
-        return new HSMessage(id, type, curView, node, qc, true);
+        return new HSMessage(id, recipient, type, curView, node, qc, true);
     }
 
     /**
@@ -163,17 +162,17 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
      * Replica: Start timer.
      */
     @Override
-    public List<Payload<HSMessage>> initializationPayloads() {
+    public List<HSMessage> initializationPayloads() {
         if (id == leader) {
             curProposal = createLeaf(null, new HSCommand(curView));
-            broadcastMessage(msg(HSMessageType.PREPARE, curProposal, highQc));
+            broadcastMessage(id -> msg(id, HSMessageType.PREPARE, curProposal, highQc));
         }
         startHsTimer();
         return getMessages();
     }
 
     @Override
-    public List<Payload<HSMessage>> processMessage(HSMessage message) {
+    public List<HSMessage> processMessage(HSMessage message) {
         int messageView = message.getViewNumber();
         HSMessageType type = message.getMessageType();
         if (messageView < curView - 1 || (type != HSMessageType.NEW_VIEW && messageView == curView - 1)) {
@@ -213,7 +212,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
                 highQc = getMaxViewNumberQc(newViewMessages);
                 // creates a generic command as the contents are not important
                 curProposal = createLeaf(highQc != null ? highQc.getNode() : null, new HSCommand(curView));
-                broadcastMessage(msg(HSMessageType.PREPARE, curProposal, highQc));
+                broadcastMessage(id -> msg(id, HSMessageType.PREPARE, curProposal, highQc));
             }
         }
         if (hasLeaderMessage()) {
@@ -221,7 +220,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (m.getSender() == leader && matchingMessage(m, HSMessageType.PREPARE, curView)) {
                 if (m.getJustify() == null || (m.getNode().extendsFrom(m.getJustify().getNode()) &&
                         safeNode(m.getNode(), m.getJustify()))) {
-                    sendMessage(voteMsg(HSMessageType.PREPARE, m.getNode(), null), getNameFromId(leader));
+                    sendMessage(voteMsg(leader, HSMessageType.PREPARE, m.getNode(), null));
                     state = HSMessageType.PRE_COMMIT;
                     preCommitOperation();
                 }
@@ -255,15 +254,14 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.PREPARE, curView, n - f)) {
                 List<HSMessage> prepareMessages = messageHolder.getVoteMessages(HSMessageType.PREPARE, curView);
                 prepareQc = new QuorumCertificate(prepareMessages);
-                broadcastMessage(msg(HSMessageType.PRE_COMMIT, null, prepareQc));
+                broadcastMessage(id -> msg(id, HSMessageType.PRE_COMMIT, null, prepareQc));
             }
         }
         if (hasLeaderMessage()) {
             HSMessage m = getLeaderMessage();
             if (m.getSender() == leader && matchingQc(m.getJustify(), HSMessageType.PREPARE, curView)) {
                 prepareQc = m.getJustify();
-                sendMessage(voteMsg(HSMessageType.PRE_COMMIT,
-                        m.getJustify().getNode(), null), getNameFromId(leader));
+                sendMessage(voteMsg(leader, HSMessageType.PRE_COMMIT, m.getJustify().getNode(), null));
                 state = HSMessageType.COMMIT;
                 commitOperation();
             }
@@ -279,14 +277,14 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.PRE_COMMIT, curView, n - f)) {
                 List<HSMessage> preCommitMessages = messageHolder.getVoteMessages(HSMessageType.PRE_COMMIT, curView);
                 preCommitQc = new QuorumCertificate(preCommitMessages);
-                broadcastMessage(msg(HSMessageType.COMMIT, null, preCommitQc));
+                broadcastMessage(id -> msg(id, HSMessageType.COMMIT, null, preCommitQc));
             }
         }
         if (hasLeaderMessage()) {
             HSMessage m = getLeaderMessage();
             if (m.getSender() == leader && matchingQc(m.getJustify(), HSMessageType.PRE_COMMIT, curView)) {
                 lockedQc = m.getJustify();
-                sendMessage(voteMsg(HSMessageType.COMMIT, m.getJustify().getNode(), null), getNameFromId(leader));
+                sendMessage(voteMsg(leader, HSMessageType.COMMIT, m.getJustify().getNode(), null));
                 state = HSMessageType.DECIDE;
                 decideOperation();
             }
@@ -302,7 +300,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.COMMIT, curView, n - f)) {
                 List<HSMessage> commitMessages = messageHolder.getVoteMessages(HSMessageType.COMMIT, curView);
                 commitQc = new QuorumCertificate(commitMessages);
-                broadcastMessage(msg(HSMessageType.DECIDE, null, commitQc));
+                broadcastMessage(id -> msg(id, HSMessageType.DECIDE, null, commitQc));
                 return;
             }
         }
@@ -345,8 +343,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
      */
     private void startNextView() {
         leader = getLeader(curView + 1);
-        sendMessage(voteMsg(HSMessageType.NEW_VIEW, null, prepareQc),
-                getNameFromId(leader));
+        sendMessage(voteMsg(leader, HSMessageType.NEW_VIEW, null, prepareQc));
         startHsTimer();
         messageHolder.advanceView(curView, curView + 1);
         curView++;

--- a/src/main/java/simulation/protocol/hotstuff/HSReplica.java
+++ b/src/main/java/simulation/protocol/hotstuff/HSReplica.java
@@ -166,10 +166,10 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
     public List<Payload<HSMessage>> initializationPayloads() {
         if (id == leader) {
             curProposal = createLeaf(null, new HSCommand(curView));
-            broadcastMessageToAll(msg(HSMessageType.PREPARE, curProposal, highQc));
+            broadcastMessage(msg(HSMessageType.PREPARE, curProposal, highQc));
         }
         startHsTimer();
-        return getProcessedPayloads();
+        return getMessages();
     }
 
     @Override
@@ -198,7 +198,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
                 decideOperation();
                 break;
         }
-        return getProcessedPayloads();
+        return getMessages();
     }
 
     /**
@@ -213,7 +213,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
                 highQc = getMaxViewNumberQc(newViewMessages);
                 // creates a generic command as the contents are not important
                 curProposal = createLeaf(highQc != null ? highQc.getNode() : null, new HSCommand(curView));
-                broadcastMessageToAll(msg(HSMessageType.PREPARE, curProposal, highQc));
+                broadcastMessage(msg(HSMessageType.PREPARE, curProposal, highQc));
             }
         }
         if (hasLeaderMessage()) {
@@ -255,7 +255,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.PREPARE, curView, n - f)) {
                 List<HSMessage> prepareMessages = messageHolder.getVoteMessages(HSMessageType.PREPARE, curView);
                 prepareQc = new QuorumCertificate(prepareMessages);
-                broadcastMessageToAll(msg(HSMessageType.PRE_COMMIT, null, prepareQc));
+                broadcastMessage(msg(HSMessageType.PRE_COMMIT, null, prepareQc));
             }
         }
         if (hasLeaderMessage()) {
@@ -279,7 +279,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.PRE_COMMIT, curView, n - f)) {
                 List<HSMessage> preCommitMessages = messageHolder.getVoteMessages(HSMessageType.PRE_COMMIT, curView);
                 preCommitQc = new QuorumCertificate(preCommitMessages);
-                broadcastMessageToAll(msg(HSMessageType.COMMIT, null, preCommitQc));
+                broadcastMessage(msg(HSMessageType.COMMIT, null, preCommitQc));
             }
         }
         if (hasLeaderMessage()) {
@@ -302,7 +302,7 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
             if (messageHolder.hasQuorumOfMessages(HSMessageType.COMMIT, curView, n - f)) {
                 List<HSMessage> commitMessages = messageHolder.getVoteMessages(HSMessageType.COMMIT, curView);
                 commitQc = new QuorumCertificate(commitMessages);
-                broadcastMessageToAll(msg(HSMessageType.DECIDE, null, commitQc));
+                broadcastMessage(msg(HSMessageType.DECIDE, null, commitQc));
                 return;
             }
         }
@@ -332,12 +332,12 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
      * On timeout, starts the next view.
      */
     @Override
-    protected List<Payload<HSMessage>> onTimerExpiry() {
+    protected List<HSMessage> onTimerExpiry() {
         numConsecutiveFailures++;
 //        logger.log(String.format("Time: %s, Name: %s, (EXPIRY) State: %s, Leader: %s, CurView: %s, Consensus: %s, Consecutive Failures: %s",
 //                getTime(), getName(), state, getLeader(curView), curView, numConsensus, numConsecutiveFailures));
         startNextView();
-        return getProcessedPayloads();
+        return getMessages();
     }
 
     /**

--- a/src/main/java/simulation/protocol/hotstuff/HSReplica.java
+++ b/src/main/java/simulation/protocol/hotstuff/HSReplica.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -50,11 +49,9 @@ public class HSReplica extends ConsensusProgramImpl<HSMessage> {
      * @param baseTimeLimit Base time limit for timeouts.
      * @param timerNotifier TimerNotifier used to get time and set timeouts.
      * @param n Number of nodes in the simulation.
-     * @param idNodeNameMap Map of node ids to their names in the network.
      * @param timerNotifier Time notifier to be used for setting timers.
      */
     public HSReplica(String name, int id, double baseTimeLimit, int n,
-            Map<Integer, String> idNodeNameMap,
             TimerNotifier<ConsensusProgram<HSMessage>> timerNotifier) {
         super(n, timerNotifier);
         this.logger = new Logger(name);

--- a/src/main/java/simulation/protocol/ibft/IBFTMessage.java
+++ b/src/main/java/simulation/protocol/ibft/IBFTMessage.java
@@ -17,18 +17,20 @@ public class IBFTMessage extends BFTMessage {
      */
     public static final int NULL_VALUE = -1;
 
-    private int identifier;
-    private IBFTMessageType messageType;
-    private int lambda;
-    private int round;
-    private int value;
-    private int preparedRound;
-    private int preparedValue;
-    private List<IBFTMessage> piggybackMessages;
+    private final int identifier;
+    private final int recipient;
+    private final IBFTMessageType messageType;
+    private final int lambda;
+    private final int round;
+    private final int value;
+    private final int preparedRound;
+    private final int preparedValue;
+    private final List<IBFTMessage> piggybackMessages;
 
-    private IBFTMessage(int identifier, IBFTMessageType messageType, int lambda,
+    private IBFTMessage(int identifier, int recipient, IBFTMessageType messageType, int lambda,
                 int round, int value, int preparedRound, int preparedValue) {
         this.identifier = identifier;
+        this.recipient = recipient;
         this.messageType = messageType;
         this.lambda = lambda;
         this.round = round;
@@ -38,9 +40,10 @@ public class IBFTMessage extends BFTMessage {
         this.piggybackMessages = List.of();
     }
 
-    private IBFTMessage(int identifier, IBFTMessageType messageType, int lambda,
+    private IBFTMessage(int identifier, int recipient, IBFTMessageType messageType, int lambda,
             int round, int value, int preparedRound, int preparedValue, List<IBFTMessage> piggybackMessages) {
         this.identifier = identifier;
+        this.recipient = recipient;
         this.messageType = messageType;
         this.lambda = lambda;
         this.round = round;
@@ -53,34 +56,35 @@ public class IBFTMessage extends BFTMessage {
     /**
      * Creates an IBFT message of the given {@code type} and specified {@code value}.
      */
-    public static IBFTMessage createValueMessage(int identifier, IBFTMessageType type,
+    public static IBFTMessage createValueMessage(int identifier, int recipient, IBFTMessageType type,
             int lambda, int round, int value) {
-        return new IBFTMessage(identifier, type, lambda, round, value, NULL_VALUE, NULL_VALUE);
+        return new IBFTMessage(identifier, recipient, type, lambda, round, value, NULL_VALUE, NULL_VALUE);
     }
 
     /**
      * Creates an IBFT message of the given {@code type} and specified {@code value} with {@code piggybackMessages}.
      */
-    public static IBFTMessage createValueMessage(int identifier, IBFTMessageType type,
+    public static IBFTMessage createValueMessage(int identifier, int recipient, IBFTMessageType type,
             int lambda, int round, int value, List<IBFTMessage> piggybackMessages) {
-        return new IBFTMessage(identifier, type, lambda, round, value,
+        return new IBFTMessage(identifier, recipient, type, lambda, round, value,
                 NULL_VALUE, NULL_VALUE, piggybackMessages);
     }
 
     /**
      * Creates an IBFT message with {@code preparedRound} and {@code preparedValue} specified.
      */
-    public static IBFTMessage createPreparedValuesMessage(int identifier, IBFTMessageType messageType,
+    public static IBFTMessage createPreparedValuesMessage(int identifier, int recipient, IBFTMessageType messageType,
             int lambda, int round, int preparedRound, int preparedValue) {
-        return new IBFTMessage(identifier, messageType, lambda, round, NULL_VALUE, preparedRound, preparedValue);
+        return new IBFTMessage(identifier, recipient, messageType, lambda, round, NULL_VALUE,
+                preparedRound, preparedValue);
     }
 
     /**
      * Creates an IBFT message with {@code preparedRound} and {@code preparedValue} with {@code piggybackMessages}.
      */
-    public static IBFTMessage createPreparedValuesMessage(int identifier, IBFTMessageType messageType,
+    public static IBFTMessage createPreparedValuesMessage(int identifier, int recipient, IBFTMessageType messageType,
             int lambda, int round, int preparedRound, int preparedValue, List<IBFTMessage> piggybackMessages) {
-        return new IBFTMessage(identifier, messageType, lambda, round, NULL_VALUE,
+        return new IBFTMessage(identifier, recipient, messageType, lambda, round, NULL_VALUE,
                 preparedRound, preparedValue, piggybackMessages);
     }
 
@@ -128,5 +132,10 @@ public class IBFTMessage extends BFTMessage {
     @Override
     public String getType() {
         return getMessageType().toString();
+    }
+
+    @Override
+    public int getRecipientId() {
+        return recipient;
     }
 }

--- a/src/main/java/simulation/protocol/ibft/IBFTNode.java
+++ b/src/main/java/simulation/protocol/ibft/IBFTNode.java
@@ -62,11 +62,9 @@ public class IBFTNode extends ConsensusProgramImpl<IBFTMessage> {
      * @param id Unique integer identifier for IBFT validator.
      * @param baseTimeLimit Base time limit for timeouts.
      * @param N Number of nodes in the simulation.
-     * @param idNodeNameMap Map of node ids to their names in the network.
      * @param timerNotifier Time notifier to be used for setting timers.
      */
     public IBFTNode(String name, int id, double baseTimeLimit, int N,
-            Map<Integer, String> idNodeNameMap,
             TimerNotifier<ConsensusProgram<IBFTMessage>> timerNotifier) {
         super(N, timerNotifier);
         logger = new Logger(name);

--- a/src/main/java/simulation/simulator/RunConfigUtil.java
+++ b/src/main/java/simulation/simulator/RunConfigUtil.java
@@ -61,7 +61,7 @@ public class RunConfigUtil {
             for (int i = 0; i < numNodes; i++) {
                 Validator<HSMessage> currentNode = hsNodes.get(i);
                 ConsensusProgram<HSMessage> program = new HSReplica(idNameMap.get(i), i, baseTimeLimit,
-                        numNodes, idNameMap, currentNode);
+                        numNodes, currentNode);
                 currentNode.addConsensusProgram(program);
             }
 
@@ -79,7 +79,7 @@ public class RunConfigUtil {
             for (int i = 0; i < numNodes; i++) {
                 Validator<IBFTMessage> currentNode = ibftNodes.get(i);
                 ConsensusProgram<IBFTMessage> program = new IBFTNode(idNameMap.get(i), i, baseTimeLimit,
-                        numNodes, idNameMap, currentNode);
+                        numNodes, currentNode);
                 currentNode.addConsensusProgram(program);
             }
 
@@ -111,6 +111,9 @@ public class RunConfigUtil {
         for (int i = 0; i < numNodes; i++) {
             String nodeName = "Val-" + i;
             idNameMap.put(i, nodeName);
+        }
+        for (int i = 0; i < numNodes; i++) {
+            String nodeName = "Val-" + i;
             Validator<T> faultyNode;
             if (i < numFaults) {
                 switch (faultType) {
@@ -122,7 +125,7 @@ public class RunConfigUtil {
                 }
                 nodes.add(faultyNode);
             } else {
-                nodes.add(new Validator<>(nodeName, consensusLimit, timerNotifier, nodeRng));
+                nodes.add(new Validator<>(nodeName, idNameMap, consensusLimit, timerNotifier, nodeRng));
             }
         }
         return new Pair<>(nodes, idNameMap);

--- a/src/main/java/simulation/simulator/RunConfigUtil.java
+++ b/src/main/java/simulation/simulator/RunConfigUtil.java
@@ -62,7 +62,7 @@ public class RunConfigUtil {
                 Validator<HSMessage> currentNode = hsNodes.get(i);
                 ConsensusProgram<HSMessage> program = new HSReplica(idNameMap.get(i), i, baseTimeLimit,
                         numNodes, idNameMap, currentNode);
-                currentNode.setConsensusProgram(program);
+                currentNode.addConsensusProgram(program);
             }
 
             hsSimulator.setNodes(hsNodes);
@@ -80,7 +80,7 @@ public class RunConfigUtil {
                 Validator<IBFTMessage> currentNode = ibftNodes.get(i);
                 ConsensusProgram<IBFTMessage> program = new IBFTNode(idNameMap.get(i), i, baseTimeLimit,
                         numNodes, idNameMap, currentNode);
-                currentNode.setConsensusProgram(program);
+                currentNode.addConsensusProgram(program);
             }
 
             ibftSimulator.setNodes(ibftNodes);

--- a/src/main/java/simulation/simulator/RunConfigUtil.java
+++ b/src/main/java/simulation/simulator/RunConfigUtil.java
@@ -60,9 +60,12 @@ public class RunConfigUtil {
 
             for (int i = 0; i < numNodes; i++) {
                 Validator<HSMessage> currentNode = hsNodes.get(i);
-                ConsensusProgram<HSMessage> program = new HSReplica(idNameMap.get(i), i, baseTimeLimit,
-                        numNodes, currentNode);
-                currentNode.addConsensusProgram(program);
+                for (int j = 0; j < validatorSettings.getNumPrograms(); j++) {
+                    String programName = idNameMap.get(i) + "-P" + j;
+                    ConsensusProgram<HSMessage> program = new HSReplica(programName, i, baseTimeLimit,
+                            numNodes, currentNode);
+                    currentNode.addConsensusProgram(program);
+                }
             }
 
             hsSimulator.setNodes(hsNodes);
@@ -78,9 +81,12 @@ public class RunConfigUtil {
 
             for (int i = 0; i < numNodes; i++) {
                 Validator<IBFTMessage> currentNode = ibftNodes.get(i);
-                ConsensusProgram<IBFTMessage> program = new IBFTNode(idNameMap.get(i), i, baseTimeLimit,
-                        numNodes, currentNode);
-                currentNode.addConsensusProgram(program);
+                for (int j = 0; j < validatorSettings.getNumPrograms(); j++) {
+                    String programName = idNameMap.get(i) + "-P" + j;
+                    ConsensusProgram<IBFTMessage> program = new IBFTNode(programName, i, baseTimeLimit,
+                            numNodes, currentNode);
+                    currentNode.addConsensusProgram(program);
+                }
             }
 
             ibftSimulator.setNodes(ibftNodes);

--- a/src/main/java/simulation/simulator/SimulatorImpl.java
+++ b/src/main/java/simulation/simulator/SimulatorImpl.java
@@ -153,8 +153,8 @@ public class SimulatorImpl<T extends BFTMessage> implements Simulator, TimerNoti
     }
 
     @Override
-    public void notifyAtTime(Validator<T> node, double time, int timerCount) {
-        eventQueue.add(new TimedEvent<T>(time, node, timerCount));
+    public void notifyAtTime(Validator<T> node, double time, int id, int timerCount) {
+        eventQueue.add(new TimedEvent<>(time, node, id, timerCount));
     }
 
     @Override

--- a/src/main/java/simulation/simulator/SimulatorImpl.java
+++ b/src/main/java/simulation/simulator/SimulatorImpl.java
@@ -121,18 +121,18 @@ public class SimulatorImpl<T extends BFTMessage> implements Simulator, TimerNoti
     @Override
     public RunResults getRunResults() {
         ConsensusStatistics fastestRunConsensusStats = nodes.stream()
-                .map(Validator::getConsensusStatistics)
+                .map(v -> v.getConsensusStatistics(1))
                 .sorted(new ConsensusTimeComparator())
                 .limit(n - f)
                 .reduce(ConsensusStatistics::combineStatistics).orElseThrow();
         ConsensusStatistics remainderRunConsensusStats = nodes.stream()
-                .map(Validator::getConsensusStatistics)
+                .map(v -> v.getConsensusStatistics(1))
                 .sorted(new ConsensusTimeComparator().reversed())
                 .limit(f)
                 .reduce(ConsensusStatistics::combineStatistics).orElseThrow();
 
         Comparator<Validator<T>> consensusTimeComparatorForQueue = (n1, n2) ->
-                new ConsensusTimeComparator().compare(n1.getConsensusStatistics(), n2.getConsensusStatistics());
+                new ConsensusTimeComparator().compare(n1.getConsensusStatistics(1), n2.getConsensusStatistics(1));
         QueueStatistics fastestRunValidatorQueueStats = nodes.stream()
                 .sorted(consensusTimeComparatorForQueue)
                 .map(Node::getQueueStatistics)

--- a/src/main/java/simulation/simulator/ValidatorResults.java
+++ b/src/main/java/simulation/simulator/ValidatorResults.java
@@ -7,5 +7,6 @@ import simulation.statistics.ConsensusStatistics;
  */
 public interface ValidatorResults extends QueueResults {
 
-    ConsensusStatistics getConsensusStatistics();
+    ConsensusStatistics getConsensusStatistics(int programNumber);
+    int getNumConsensusPrograms();
 }


### PR DESCRIPTION
Allows validators to run more than 1 instance of the same consensus protocol. Statistics are calculated only for a singular consensus chain. 

The `numPrograms` field is added to `validatorSettings`.

- Timer notifications now require a program ID. Each chain will have their own program id.
- Changed programs to only communicate via message classes.
- Added recipient to all message classes.
- Changed payload wrapping to be the responsibility of the node.

