### PR TITLE
Update folded Clos topology to be more generic

### DIFF
--- a/src/main/java/simulation/BFTSimulation.java
+++ b/src/main/java/simulation/BFTSimulation.java
@@ -140,6 +140,12 @@ public class BFTSimulation {
      */
     private static void setup() {
         deleteFilesInDirectory(Logger.DEFAULT_DIRECTORY);
+
+        try {
+            Files.createDirectories(JSON_DIRECTORY);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create " + JSON_DIRECTORY + " for storing results.\n" + e);
+        }
         deleteFilesInDirectory(JSON_DIRECTORY.toString());
         Logger.setup();
     }

--- a/src/main/java/simulation/network/router/Switch.java
+++ b/src/main/java/simulation/network/router/Switch.java
@@ -120,6 +120,10 @@ public class Switch<T> extends Node<T> {
         return switchNeighbors;
     }
 
+    public List<Node<T>> getDirectlyConnectedEndpoints() {
+        return directlyConnectedEndpoints;
+    }
+
     @Override
     public Pair<Double, List<Payload<T>>> processPayload(double time, Payload<T> payload) {
         double duration = rng.generateRandomNumber();

--- a/src/main/java/simulation/network/topology/ButterflyTopology.java
+++ b/src/main/java/simulation/network/topology/ButterflyTopology.java
@@ -46,7 +46,7 @@ public class ButterflyTopology {
     }
 
     private static String getTreeSwitchName(int level, int group, int index) {
-        return String.format("(Level: %d, Group: %d, Index: %d)", level, group, index);
+        return String.format("Switch-(L:%d,G:%d,N:%d)", level, group, index);
     }
 
 

--- a/src/main/java/simulation/network/topology/DragonflyTopology.java
+++ b/src/main/java/simulation/network/topology/DragonflyTopology.java
@@ -16,9 +16,9 @@ public class DragonflyTopology {
 
     /**
      * @param nodes Nodes to be arranged in a dragonfly topology.
-     * @param networkParameters Network parameters for {radix, connection type}.
+     * @param networkParameters Network parameters for {# of switches in a group}.
      *                          Number of switches in a group - positive integer > 0
-     *
+     *                          By default, # of groups = # of switches + 1.
      * @param messageChannelSuccessRate Success rate of a message being sent by the switch.
      * @param switchProcessingTimeGenerator Rng for switch processing time.
      * @return Returns a list of list of switches separated by level in the butterfly network.
@@ -54,7 +54,9 @@ public class DragonflyTopology {
                 int correspondingGroup = i + (a - j) - numGroups * (a - j >= numGroups - i ? 1 : 0);
                 int correspondingIndex = a - 1 - j;
                 switchNeighbors.add(groupsOfSwitches.get(correspondingGroup).get(correspondingIndex));
-                groupsOfSwitches.get(i).get(j).setSwitchNeighbors(switchNeighbors);
+                Switch<T> currentSwitch = groupsOfSwitches.get(i).get(j);
+                switchNeighbors.remove(currentSwitch);
+                currentSwitch.setSwitchNeighbors(switchNeighbors);
             }
         }
 

--- a/src/main/java/simulation/network/topology/DragonflyTopology.java
+++ b/src/main/java/simulation/network/topology/DragonflyTopology.java
@@ -17,11 +17,7 @@ public class DragonflyTopology {
     /**
      * @param nodes Nodes to be arranged in a dragonfly topology.
      * @param networkParameters Network parameters for {radix, connection type}.
-     *                          Number of terminals - positive integer > 0
      *                          Number of switches in a group - positive integer > 0
-     *                          Connection type - 0 or 1. 0 for a flushed type connection and 1 for spread.
-     *                          Distribution of nodes over switches - 0 or 1. 1 for fitting into as few groups as
-     *                          possible and 0 for spreading out over as many groups as possible.
      *
      * @param messageChannelSuccessRate Success rate of a message being sent by the switch.
      * @param switchProcessingTimeGenerator Rng for switch processing time.
@@ -32,8 +28,7 @@ public class DragonflyTopology {
             List<Integer> networkParameters,
             double messageChannelSuccessRate,
             RandomNumberGenerator switchProcessingTimeGenerator) {
-        int p = networkParameters.get(0);
-        int a = networkParameters.get(1);
+        int a = networkParameters.get(0);
         int numGroups = a + 1;
         int numSwitches = a * numGroups;
         List<List<Switch<T>>> groupsOfSwitches = new ArrayList<>();
@@ -41,9 +36,9 @@ public class DragonflyTopology {
             List<Switch<T>> groupSwitches = new ArrayList<>();
             groupsOfSwitches.add(groupSwitches);
             for (int j = 0; j < a; j++) {
-                int index = networkParameters.get(3) == 1 ? i * a + j : i + j * numGroups;
+                int index = i + j * numGroups;
                 List<? extends EndpointNode<T>> endpointSublist = TopologyUtil.getEndpointSublist(
-                        nodes, networkParameters.get(2), numSwitches, p, index);
+                        nodes, numSwitches, index);
                 Switch<T> newSwitch = new Switch<>(String.format("Switch-(G:%d,N:%d)", i, j), messageChannelSuccessRate,
                         new ArrayList<>(nodes),
                         endpointSublist,

--- a/src/main/java/simulation/network/topology/TopologyUtil.java
+++ b/src/main/java/simulation/network/topology/TopologyUtil.java
@@ -13,30 +13,18 @@ public class TopologyUtil {
 
     /**
      * @param nodes Nodes to retrieve endpoint sublist from.
-     * @param param Parameter for determining flushed or spread setting. 0 for flushed, 1 for spread.
      * @param numSwitches Number of switches for direction connection.
-     * @param connections Maximum number of connections per switch.
      * @param index The index-th sublist to be retrieved. If nodes.size() < connections * index, returns empty list.
      * @return Returns the endpoint sublist corresponding to the parameters specified.
      */
-    public static <T> List<EndpointNode<T>> getEndpointSublist(List<? extends EndpointNode<T>> nodes, int param,
-            int numSwitches, int connections, int index) {
-
+    public static <T> List<EndpointNode<T>> getEndpointSublist(List<? extends EndpointNode<T>> nodes,
+            int numSwitches, int index) {
         int minEndpointPerSwitch = nodes.size() / numSwitches;
         int numAdditional = nodes.size() % numSwitches;
-        if (param == 1) {
-            // 1 for spread, 0 for flushed
-            int startIndex = index < numAdditional ? (minEndpointPerSwitch + 1) * index :
-                    ((minEndpointPerSwitch + 1) * numAdditional) + minEndpointPerSwitch * (index - numAdditional);
-            int endIndex = startIndex + minEndpointPerSwitch + (numAdditional > index ? 1 : 0);
-            return new ArrayList<>(nodes.subList(startIndex, endIndex));
-        } else if (param == 0) {
-            return (index * connections) >= nodes.size() ? List.of() :
-                    new ArrayList<>(nodes.subList(index * connections, Math.min(nodes.size(),
-                            (index + 1) * connections)));
-        } else {
-            throw new RuntimeException("Initial connection parameter (second field) must be 1 or 0.");
-        }
+        int startIndex = index < numAdditional ? (minEndpointPerSwitch + 1) * index :
+                ((minEndpointPerSwitch + 1) * numAdditional) + minEndpointPerSwitch * (index - numAdditional);
+        int endIndex = startIndex + minEndpointPerSwitch + (numAdditional > index ? 1 : 0);
+        return new ArrayList<>(nodes.subList(startIndex, endIndex));
     }
 
     /**


### PR DESCRIPTION
Updated the current foldedClos topology definition to specify only the number of level 1 nodes (remaining levels will have the same amount) and inter-switch radix. The setting for how terminal nodes are assigned is defaulted to spread since it never quite made sense to flush the terminal nodes together.

- Fixed issue where a missing `json/` directory in the home path results in program failure.
- Dragonfly topology now defaults to the most spread out configuration possible (over as many switches and as many groups).
- Dragonfly topology now only has one specification which is the number of nodes in a group, a. Number of groups defaults to a + 1.
- Removed foldedClos second configuration of maximizing for number of groups as it only served to complicate things without a proper definition or motivation.