### PR TITLE
Fix Round Change backlog bug

### DIFF
--- a/src/main/java/simulation/protocol/ibft/IBFTMessage.java
+++ b/src/main/java/simulation/protocol/ibft/IBFTMessage.java
@@ -3,6 +3,7 @@ package simulation.protocol.ibft;
 import simulation.network.entity.BFTMessage;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static simulation.util.StringUtil.MESSAGE_SEPARATOR;
@@ -50,7 +51,8 @@ public class IBFTMessage extends BFTMessage {
         this.value = value;
         this.preparedRound = preparedRound;
         this.preparedValue = preparedValue;
-        this.piggybackMessages = List.copyOf(piggybackMessages);
+        this.piggybackMessages = Optional.ofNullable(piggybackMessages).map(lst -> List.copyOf(piggybackMessages))
+                .orElse(List.of());
     }
 
     /**


### PR DESCRIPTION
There was a bug when running IBFT on a topology where a round's RC message could arrive late to another validator after already moving to the next consensus instance. This causes an NPE. This has been fixed and it assumes the correctness of the backlog-dropping mechanism, which implies that one where the backlog pulls up a null for that current consensus instance implies it is outdated.